### PR TITLE
Fixes icons' path on Linux system

### DIFF
--- a/DIE/Lib/DieConfig.py
+++ b/DIE/Lib/DieConfig.py
@@ -23,11 +23,11 @@ class DIEConfig(object):
 
     @property
     def icons_path(self):
-        return self.install_path + "\\Icons"
+        return os.path.join(self.install_path, "icons")
 
     @property
     def parser_path(self):
-        return self.install_path + "\\Plugins\\DataParsers"
+        return os.path.join(self.install_path, "Plugins", "DataParsers")
 
     def load(self, path):
         with open(path, "rb") as f:


### PR DESCRIPTION
Replaced the '\\' with `path.join` and `"Icons"` with `"icons"`.