### PR TITLE
more 6.9 support

### DIFF
--- a/DIE/UI/AboutScreen.py
+++ b/DIE/UI/AboutScreen.py
@@ -4,9 +4,9 @@ from idaapi import Form
 import os
 import DIE.Lib.DieConfig
 
-from sark.qt import QtGui, QtCore
+from cute import QtCore, QtWidgets, QtGui
 
-class AboutWindow(QtGui.QDialog):
+class AboutWindow(QtWidgets.QDialog):
     def __init__(self):
         super(AboutWindow, self).__init__()
 
@@ -21,12 +21,12 @@ class AboutWindow(QtGui.QDialog):
         pixmap = QtGui.QPixmap.fromImage(image)
 
 
-        logo = QtGui.QLabel(self)
+        logo = QtWidgets.QLabel(self)
         logo.setFixedSize(pixmap.size())
         logo.move(0.5*(self.width() - logo.width()), 20)
         logo.setPixmap(pixmap)
 
-        title = QtGui.QLabel("DIE",self)
+        title = QtWidgets.QLabel("DIE",self)
         title.setAlignment(QtCore.Qt.AlignCenter)
         font = title.font()
         font.setPointSize(16)
@@ -35,7 +35,7 @@ class AboutWindow(QtGui.QDialog):
         title.setFixedWidth(400)
         title.move(0, logo.height() + logo.y() + 20)
 
-        subtitle = QtGui.QLabel("Dynamic IDA Enrichment framework",self)
+        subtitle = QtWidgets.QLabel("Dynamic IDA Enrichment framework",self)
         font = subtitle.font()
         font.setPointSize(14)
         subtitle.setFont(font)
@@ -43,7 +43,7 @@ class AboutWindow(QtGui.QDialog):
         subtitle.setFixedWidth(400)
         subtitle.move(0, title.height() + title.y() + 10)
 
-        version = QtGui.QLabel("Version 0.1",self)
+        version = QtWidgets.QLabel("Version 0.1",self)
         font = subtitle.font()
         font.setPointSize(12)
         version.setFont(font)
@@ -51,7 +51,7 @@ class AboutWindow(QtGui.QDialog):
         version.setFixedWidth(400)
         version.move(0, subtitle.height() + subtitle.y() + 30)
 
-        author = QtGui.QLabel("Written by Yaniv Balmas @ynvb - Check Point Software Technologies",self)
+        author = QtWidgets.QLabel("Written by Yaniv Balmas @ynvb - Check Point Software Technologies",self)
         font = subtitle.font()
         font.setPointSize(12)
         author.setFont(font)

--- a/DIE/UI/BPView.py
+++ b/DIE/UI/BPView.py
@@ -1,4 +1,4 @@
-from PySide import QtGui, QtCore
+from cute import QtGui, QtCore, QtWidgets, form_to_widget
 
 from idaapi import PluginForm
 
@@ -25,22 +25,22 @@ class BreakpointView(PluginForm):
         """
         Called when the view is created
         """
-        self.bp_tree_widget = QtGui.QTreeWidget()
+        self.bp_tree_widget = QtWidgets.QTreeWidget()
         self.bp_handler = BpHandler.get_bp_handler()
         self.die_icons = DIE.UI.Die_Icons.get_die_icons()
 
         # Get parent widget
-        self.parent = self.FormToPySideWidget(form)
+        self.parent = form_to_widget(form)
 
         self._add_parser_data()
 
-        toolbar = QtGui.QToolBar()
-        action_refresh = QtGui.QAction(self.die_icons.icon_refresh, "Refresh", toolbar)
+        toolbar = QtWidgets.QToolBar()
+        action_refresh = QtWidgets.QAction(self.die_icons.icon_refresh, "Refresh", toolbar)
         action_refresh.triggered.connect(self.refresh)
         toolbar.addAction(action_refresh)
 
 
-        layout = QtGui.QGridLayout()
+        layout = QtWidgets.QGridLayout()
         layout.addWidget(toolbar)
         layout.addWidget(self.bp_tree_widget)
 
@@ -59,46 +59,46 @@ class BreakpointView(PluginForm):
         if self.bp_tree_widget is not None:
             self.bp_tree_widget.clear()
         else:
-            self.bp_tree_widget = QtGui.QTreeWidget()
+            self.bp_tree_widget = QtWidgets.QTreeWidget()
 
         root_item = self.bp_tree_widget.invisibleRootItem()
 
         self.bp_tree_widget.setHeaderLabel("Breakpoints")
 
         # Excluded Modules
-        module_item = QtGui.QTreeWidgetItem()
+        module_item = QtWidgets.QTreeWidgetItem()
         module_item.setText(0, "Excluded Modules")
         module_item.setFlags(QtCore.Qt.ItemIsEnabled)
 
         row = 0
         for module in self.bp_handler.excluded_modules:
-            current_row_item = QtGui.QTreeWidgetItem()
+            current_row_item = QtWidgets.QTreeWidgetItem()
             current_row_item.setFlags(QtCore.Qt.ItemIsEnabled)
             current_row_item.setText(0, module)
             module_item.insertChild(row, current_row_item)
             row += 1
 
         # Excluded Functions
-        function_item = QtGui.QTreeWidgetItem()
+        function_item = QtWidgets.QTreeWidgetItem()
         function_item.setText(0, "Excluded Functions")
         function_item.setFlags(QtCore.Qt.ItemIsEnabled)
 
         row = 0
         for function in self.bp_handler.excluded_funcNames:
-            current_row_item = QtGui.QTreeWidgetItem()
+            current_row_item = QtWidgets.QTreeWidgetItem()
             current_row_item.setFlags(QtCore.Qt.ItemIsEnabled)
             current_row_item.setText(0, function)
             function_item.insertChild(row, current_row_item)
             row += 1
 
         # Excluded Addresses
-        ea_item = QtGui.QTreeWidgetItem()
+        ea_item = QtWidgets.QTreeWidgetItem()
         ea_item.setText(0, "Excluded Addresses")
         ea_item.setFlags(QtCore.Qt.ItemIsEnabled)
 
         row = 0
         for ea in self.bp_handler.excluded_bp_ea:
-            current_row_item = QtGui.QTreeWidgetItem()
+            current_row_item = QtWidgets.QTreeWidgetItem()
             current_row_item.setFlags(QtCore.Qt.ItemIsEnabled)
             current_row_item.setText(0, hex(ea))
             ea_item.insertChild(row, current_row_item)

--- a/DIE/UI/Die_Icons.py
+++ b/DIE/UI/Die_Icons.py
@@ -2,7 +2,7 @@ from DIE.Lib import DieConfig
 import idaapi
 import os
 import DIE.Lib.DieConfig
-from PySide import QtGui
+from cute import QtGui
 
 
 class DieIcons():

--- a/DIE/UI/FunctionViewEx.py
+++ b/DIE/UI/FunctionViewEx.py
@@ -6,7 +6,15 @@ import idaapi
 import idautils
 import idc
 from idaapi import PluginForm
-from PySide import QtGui, QtCore
+from cute import QtGui, QtCore, QtWidgets, form_to_widget, use_qt5
+if use_qt5:
+    # should be done in cute.py
+    QtCore.Slot = QtCore.pyqtSlot
+    QtCore.Qt.MatchFlag.MatchRecursive = QtCore.Qt.MatchRecursive
+    QtCore.Qt.MatchFlag.MatchExactly = QtCore.Qt.MatchExactly
+    QtWidgets.QAbstractItemView.ScrollHint.PositionAtTop = QtWidgets.QAbstractItemView.PositionAtTop
+    QtCore.Qt.GlobalColor.yellow = QtCore.Qt.yellow
+    QtCore.Qt.GlobalColor.white = QtCore.Qt.white
 
 import DIE.UI.Die_Icons
 import DIE.UI.ValueViewEx
@@ -50,10 +58,10 @@ class FunctionView(PluginForm):
         self.die_db = DIE.Lib.DIEDb.get_db()
 
         # Get parent widget
-        self.parent = self.FormToPySideWidget(form)
+        self.parent = form_to_widget(form) 
 
         self.functionModel = QtGui.QStandardItemModel()
-        self.functionTreeView = QtGui.QTreeView()
+        self.functionTreeView = QtWidgets.QTreeView()
         self.functionTreeView.setExpandsOnDoubleClick(False)
         #self.functionTreeView.setSortingEnabled(True)
 
@@ -83,27 +91,27 @@ class FunctionView(PluginForm):
         # Actions
         self.context_menu_param = None  # Parameter to be passed to context menu slots
 
-        action_exclude_func = QtGui.QAction("Exclude Function", self.functionTreeView, triggered=lambda: self.on_exclude_func(self.context_menu_param))
-        action_exclude_func_adrs = QtGui.QAction("Exclude All Function Calls", self.functionTreeView, triggered=lambda: self.on_exclude_func_adrs(self.context_menu_param))
-        action_exclude_ea = QtGui.QAction("Exclude Address", self.functionTreeView, triggered=lambda: self.on_exclude_ea(self.context_menu_param))
-        action_exclude_library = QtGui.QAction("Exclude Library", self.functionTreeView, triggered=lambda: self.on_exclude_library(self.context_menu_param))
-        action_value_detail = QtGui.QAction("Inspect Value Details", self.functionTreeView, triggered=lambda: self.on_value_detail(self.context_menu_param))
+        action_exclude_func = QtWidgets.QAction("Exclude Function", self.functionTreeView, triggered=lambda: self.on_exclude_func(self.context_menu_param))
+        action_exclude_func_adrs = QtWidgets.QAction("Exclude All Function Calls", self.functionTreeView, triggered=lambda: self.on_exclude_func_adrs(self.context_menu_param))
+        action_exclude_ea = QtWidgets.QAction("Exclude Address", self.functionTreeView, triggered=lambda: self.on_exclude_ea(self.context_menu_param))
+        action_exclude_library = QtWidgets.QAction("Exclude Library", self.functionTreeView, triggered=lambda: self.on_exclude_library(self.context_menu_param))
+        action_value_detail = QtWidgets.QAction("Inspect Value Details", self.functionTreeView, triggered=lambda: self.on_value_detail(self.context_menu_param))
 
-        action_show_callgraph = QtGui.QAction("Show Call-Graph", self.functionTreeView, triggered=lambda: self.on_show_callgraph(self.context_menu_param))
+        action_show_callgraph = QtWidgets.QAction("Show Call-Graph", self.functionTreeView, triggered=lambda: self.on_show_callgraph(self.context_menu_param))
 
         # Function ContextMenu
-        self.function_context_menu = QtGui.QMenu(self.functionTreeView)
+        self.function_context_menu = QtWidgets.QMenu(self.functionTreeView)
         self.function_context_menu.addAction(action_exclude_func)
         self.function_context_menu.addAction(action_exclude_library)
         self.function_context_menu.addAction(action_exclude_func_adrs)
 
         # Function ea ContextMenu
-        self.ea_context_menu = QtGui.QMenu(self.functionTreeView)
+        self.ea_context_menu = QtWidgets.QMenu(self.functionTreeView)
         self.ea_context_menu.addAction(action_exclude_ea)
         self.ea_context_menu.addAction(action_show_callgraph)
 
         # Argument value ContextMenu
-        self.value_context_menu = QtGui.QMenu(self.functionTreeView)
+        self.value_context_menu = QtWidgets.QMenu(self.functionTreeView)
         self.value_context_menu.addAction(action_value_detail)
 
         # Therad ComboBox
@@ -116,19 +124,19 @@ class FunctionView(PluginForm):
         for thread in threads:
             thread_id_list.append(str(thread.thread_num))
 
-        self.thread_id_combo = QtGui.QComboBox()
+        self.thread_id_combo = QtWidgets.QComboBox()
         self.thread_id_combo.addItems(thread_id_list)
         self.thread_id_combo.activated[str].connect(self.on_thread_combobox_change)
 
-        self.thread_id_label = QtGui.QLabel("Thread:  ")
+        self.thread_id_label = QtWidgets.QLabel("Thread:  ")
 
         # Toolbar
-        self.function_toolbar = QtGui.QToolBar()
+        self.function_toolbar = QtWidgets.QToolBar()
         self.function_toolbar.addWidget(self.thread_id_label)
         self.function_toolbar.addWidget(self.thread_id_combo)
 
         # Grid
-        layout = QtGui.QGridLayout()
+        layout = QtWidgets.QGridLayout()
         layout.addWidget(self.function_toolbar)
         layout.addWidget(self.functionTreeView)
 
@@ -732,7 +740,7 @@ class FunctionView(PluginForm):
 
         for item in matched_items:
             self.functionTreeView.expand(item.index())
-            self.functionTreeView.scrollTo(item.index(), QtGui.QAbstractItemView.ScrollHint.PositionAtTop)
+            self.functionTreeView.scrollTo(item.index(), QtWidgets.QAbstractItemView.ScrollHint.PositionAtTop)
             self.highlight_item_row(item)
 
     def find_context_list(self, context_list):
@@ -759,7 +767,7 @@ class FunctionView(PluginForm):
 
                     item = self.functionModel.itemFromIndex(index)
                     self.functionTreeView.expand(index)
-                    self.functionTreeView.scrollTo(index, QtGui.QAbstractItemView.ScrollHint.PositionAtTop)
+                    self.functionTreeView.scrollTo(index, QtWidgets.QAbstractItemView.ScrollHint.PositionAtTop)
                     self.highlight_item_row(item)
 
             return True
@@ -912,7 +920,7 @@ class FunctionView(PluginForm):
 
         hidden_threads = ".*" + self._make_thread_id_data(thread_id) + ".*"
 
-        threadProxyModel = QtGui.QSortFilterProxyModel()
+        threadProxyModel = QtCore.QSortFilterProxyModel()
         threadProxyModel.setFilterRole(DIE.UI.ThreadId_Role)
         threadProxyModel.setFilterRegExp(hidden_threads)
 
@@ -937,13 +945,13 @@ class FunctionView(PluginForm):
 ###############################################################################################
 #  View Delegates.
 
-class TreeViewDelegate(QtGui.QStyledItemDelegate):
+class TreeViewDelegate(QtWidgets.QStyledItemDelegate):
     """
     Delegate for parsed value viewing in the tree view
     """
 
     def __init__(self, parent):
-        QtGui.QStyledItemDelegate.__init__(self, parent)
+        QtWidgets.QStyledItemDelegate.__init__(self, parent)
         self.parent = parent
 
     def createEditor(self, parent, option, index):
@@ -957,7 +965,7 @@ class TreeViewDelegate(QtGui.QStyledItemDelegate):
                 line_txt = "%d, %s, %s" % (parsed_val.score, parsed_val.data, parsed_val.description)
                 lines.append(line_txt)
 
-            combo_box = QtGui.QComboBox(parent)
+            combo_box = QtWidgets.QComboBox(parent)
             combo_box.addItems(lines)
 
             return combo_box

--- a/DIE/UI/ParserView.py
+++ b/DIE/UI/ParserView.py
@@ -1,6 +1,6 @@
 from DIE.Lib import DataParser
 from idaapi import PluginForm
-from PySide import QtGui, QtCore
+from cute import QtGui, QtCore, QtWidgets, form_to_widget
 
 
 class ParserView(PluginForm):
@@ -23,14 +23,14 @@ class ParserView(PluginForm):
         Called when the view is created
         """
         self.data_parser = DataParser.getParser()
-        self.ptable_widget = QtGui.QTreeWidget()
+        self.ptable_widget = QtWidgets.QTreeWidget()
 
         # Get parent widget
-        self.parent = self.FormToPySideWidget(form)
+        self.parent = form_to_widget(form) 
 
         self._add_parser_data()
 
-        layout = QtGui.QGridLayout()
+        layout = QtWidgets.QGridLayout()
         layout.addWidget(self.ptable_widget)
 
         self.parent.setLayout(layout)
@@ -61,7 +61,7 @@ class ParserView(PluginForm):
         root_item = self.ptable_widget.invisibleRootItem()
 
         for parser in parser_list:
-            current_row_item = QtGui.QTreeWidgetItem()
+            current_row_item = QtWidgets.QTreeWidgetItem()
             current_row_item.setFlags(QtCore.Qt.ItemIsEnabled)
             current_row_item.setText(0, parser)
 

--- a/DIE/UI/ValueViewEx.py
+++ b/DIE/UI/ValueViewEx.py
@@ -1,6 +1,14 @@
 
 
-from PySide import QtGui, QtCore
+from cute import QtGui, QtCore, QtWidgets, form_to_widget, use_qt5
+if use_qt5:
+    # should be done in cute.py
+    QtCore.Slot = QtCore.pyqtSlot
+    QtCore.Qt.MatchFlag.MatchRecursive = QtCore.Qt.MatchRecursive
+    QtCore.Qt.MatchFlag.MatchExactly = QtCore.Qt.MatchExactly
+    QtWidgets.QAbstractItemView.ScrollHint.PositionAtTop = QtWidgets.QAbstractItemView.PositionAtTop
+    QtCore.Qt.GlobalColor.yellow = QtCore.Qt.yellow
+    QtCore.Qt.GlobalColor.white = QtCore.Qt.white
 
 import idaapi
 import idautils
@@ -37,10 +45,10 @@ class ValueView(PluginForm):
         self.function_view = DIE.UI.FunctionViewEx.get_view()
 
         # Get parent widget
-        self.parent = self.FormToPySideWidget(form)
+        self.parent = form_to_widget(form) 
 
         self.valueModel = QtGui.QStandardItemModel()
-        self.valueTreeView = QtGui.QTreeView()
+        self.valueTreeView = QtWidgets.QTreeView()
         self.valueTreeView.setExpandsOnDoubleClick(False)
 
         self.valueTreeView.doubleClicked.connect(self.itemDoubleClickSlot)
@@ -49,7 +57,7 @@ class ValueView(PluginForm):
         self.valueTreeView.setModel(self.valueModel)
 
         # Toolbar
-        self.value_toolbar = QtGui.QToolBar()
+        self.value_toolbar = QtWidgets.QToolBar()
 
         # Value type combobox
         type_list = []
@@ -57,16 +65,16 @@ class ValueView(PluginForm):
             type_list = self.die_db.get_all_value_types()
             type_list.insert(0, "All Values")
 
-        self.value_type_combo = QtGui.QComboBox()
+        self.value_type_combo = QtWidgets.QComboBox()
         self.value_type_combo.addItems(type_list)
         self.value_type_combo.activated[str].connect(self.on_value_type_combobox_change)
 
-        self.value_type_label = QtGui.QLabel("Value Type:  ")
+        self.value_type_label = QtWidgets.QLabel("Value Type:  ")
         self.value_toolbar.addWidget(self.value_type_label)
         self.value_toolbar.addWidget(self.value_type_combo)
 
         # Layout
-        layout = QtGui.QGridLayout()
+        layout = QtWidgets.QGridLayout()
         layout.addWidget(self.value_toolbar)
         layout.addWidget(self.valueTreeView)
 
@@ -236,7 +244,7 @@ class ValueView(PluginForm):
 
                 item = self.valueModel.itemFromIndex(index)
                 self.valueTreeView.expand(index)
-                self.valueTreeView.scrollTo(index, QtGui.QAbstractItemView.ScrollHint.PositionAtTop)
+                self.valueTreeView.scrollTo(index, QtWidgets.QAbstractItemView.ScrollHint.PositionAtTop)
                 self.highlight_item_row(item)
 
         except Exception as ex:
@@ -280,7 +288,7 @@ class ValueView(PluginForm):
                 self.valueTreeView.setModel(self.valueModel)
             return
 
-        valuetypeProxyModel = QtGui.QSortFilterProxyModel()
+        valuetypeProxyModel = QtCore.QSortFilterProxyModel()
         valuetypeProxyModel.setFilterRole(DIE.UI.ValueType_Role)
         valuetypeProxyModel.setFilterRegExp(value_type)
 

--- a/DIE/UI/__init__.py
+++ b/DIE/UI/__init__.py
@@ -1,6 +1,6 @@
 
 
-from PySide import QtCore
+from cute import QtCore
 
 # Define custom data roles
 Function_Role = QtCore.Qt.UserRole+1


### PR DESCRIPTION
every `PySide` import fixed
i'm not sure, but i think that aliases like `QtCore.Slot = QtCore.pyqtSlot` should be located in `cute.py`
